### PR TITLE
Jefferson/donations page

### DIFF
--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -4,14 +4,16 @@ const donationController = {
 
   async getDonations(req, res) {
     try {
-      const { search, status, minAmount, maxAmount } = req.query
-      const donations = await donationRepository.getDonations({
+      const { search, status, minAmount, maxAmount, page, limit } = req.query
+      const { rows, total } = await donationRepository.getDonations({
         search,
         status,
         minAmount,
-        maxAmount
+        maxAmount,
+        page,
+        limit,
       })
-      res.json(donations);
+      res.json({ donations: rows, total });
     } catch (err) {
       res.status(500).json({ error: err.message });
     }

--- a/src/repositories/dashboardRepository.js
+++ b/src/repositories/dashboardRepository.js
@@ -78,7 +78,7 @@ const dashboardRepository = {
 
   async getRecentDonations() {
     const [rows] = await pool.execute(`
-      SELECT id, donor_name, amount, donation_date, receipt_status
+      SELECT id, donor_name, donor_email, amount, donation_date, receipt_status
       FROM donations
       ORDER BY donation_date DESC
       LIMIT 5

--- a/src/repositories/donationRepository.js
+++ b/src/repositories/donationRepository.js
@@ -2,39 +2,46 @@ import { pool } from '../config/database.js';
 
 const donationRepository = {
 
-  async getDonations({ search, status, minAmount, maxAmount }) {
-    let sql = `
-      SELECT id, donor_name, donor_email, amount, donation_date, receipt_status
-      FROM donations
-      WHERE 1=1
-    `
+  async getDonations({ search, status, minAmount, maxAmount, page = 1, limit = 25 }) {
+    const pageSize = parseInt(limit) || 25
+    const offset = (parseInt(page) - 1) * pageSize
+
+    let where = 'WHERE 1=1'
     const params = []
-  
+
     if (search) {
-      sql += ` AND (donor_name LIKE ? OR donor_email LIKE ?)`
+      where += ` AND (donor_name LIKE ? OR donor_email LIKE ?)`
       params.push(`%${search}%`, `%${search}%`)
     }
-  
+
     if (status) {
-      sql += ` AND receipt_status = ?`
+      where += ` AND receipt_status = ?`
       params.push(status)
     }
-  
+
     if (minAmount) {
-      sql += ` AND amount >= ?`
+      where += ` AND amount >= ?`
       params.push(minAmount)
     }
-  
+
     if (maxAmount) {
-      sql += ` AND amount <= ?`
+      where += ` AND amount <= ?`
       params.push(maxAmount)
     }
-  
-    sql += ` ORDER BY donation_date DESC`
-  
-    const [rows] = await pool.execute(sql, params)
-  
-    return rows
+
+    const [countRows] = await pool.execute(
+      `SELECT COUNT(*) AS total FROM donations ${where}`,
+      params
+    )
+    const total = parseInt(countRows[0].total)
+
+    const [rows] = await pool.execute(
+      `SELECT id, donor_name, donor_email, amount, donation_date, receipt_status
+       FROM donations ${where} ORDER BY donation_date DESC LIMIT ${pageSize} OFFSET ${offset}`,
+      params
+    )
+
+    return { rows, total }
   },
 
   async getById(id) {

--- a/src/repositories/donationRepository.js
+++ b/src/repositories/donationRepository.js
@@ -3,8 +3,10 @@ import { pool } from '../config/database.js';
 const donationRepository = {
 
   async getDonations({ search, status, minAmount, maxAmount, page = 1, limit = 25 }) {
-    const pageSize = parseInt(limit) || 25
-    const offset = (parseInt(page) - 1) * pageSize
+    const MAX_LIMIT = 100
+    const pageSize = Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT)
+    const safePage = Math.max(parseInt(page) || 1, 1)
+    const offset = (safePage - 1) * pageSize
 
     let where = 'WHERE 1=1'
     const params = []
@@ -29,19 +31,19 @@ const donationRepository = {
       params.push(maxAmount)
     }
 
-    const [countRows] = await pool.execute(
-      `SELECT COUNT(*) AS total FROM donations ${where}`,
-      params
-    )
-    const total = parseInt(countRows[0].total)
+    const [[countRows], [rows]] = await Promise.all([
+      pool.execute(
+        `SELECT COUNT(*) AS total FROM donations ${where}`,
+        params
+      ),
+      pool.execute(
+        `SELECT id, donor_name, donor_email, amount, donation_date, receipt_status
+         FROM donations ${where} ORDER BY donation_date DESC LIMIT ${pageSize} OFFSET ${offset}`,
+        params
+      ),
+    ])
 
-    const [rows] = await pool.execute(
-      `SELECT id, donor_name, donor_email, amount, donation_date, receipt_status
-       FROM donations ${where} ORDER BY donation_date DESC LIMIT ${pageSize} OFFSET ${offset}`,
-      params
-    )
-
-    return { rows, total }
+    return { rows, total: parseInt(countRows[0].total) }
   },
 
   async getById(id) {


### PR DESCRIPTION
Adds server-side pagination to GET /donations using page and limit, and updates the response to { donations, total } so the frontend can compute page counts. Also includes donor_email in /dashboard/recent-donations to align with the full donations endpoint. Refactors repository logic to share filters between COUNT and paginated queries, validates and clamps inputs (page ≥ 1, 1 ≤ limit ≤ 100), fixes a MySQL LIMIT/OFFSET issue, and improves performance by running queries in parallel. Breaking change: GET /donations no longer returns a plain array—clients must use response.donations.

TLDR: Changed shape of donations endpoint to return metadata necessary for pagination and also added email to donation table columns