### PR TITLE
Expose donor_id on donation rows

### DIFF
--- a/src/repositories/dashboardRepository.js
+++ b/src/repositories/dashboardRepository.js
@@ -1,7 +1,6 @@
 import { pool } from '../config/database.js';
 
 const dashboardRepository = {
-
   async getDashboardSummary() {
     const [allTime] = await pool.execute(`
       SELECT COALESCE(SUM(amount), 0) AS total_amount
@@ -35,9 +34,13 @@ const dashboardRepository = {
 
     const lastMonthAmount = parseFloat(lastMonth[0].last_month_amount);
     const thisMonthAmount = parseFloat(thisMonth[0].this_month_amount);
-    const growthRate = lastMonthAmount === 0
-      ? null
-      : (((thisMonthAmount - lastMonthAmount) / lastMonthAmount) * 100).toFixed(1);
+    const growthRate =
+      lastMonthAmount === 0
+        ? null
+        : (
+            ((thisMonthAmount - lastMonthAmount) / lastMonthAmount) *
+            100
+          ).toFixed(1);
 
     return {
       total_amount: parseFloat(allTime[0].total_amount),
@@ -78,14 +81,15 @@ const dashboardRepository = {
 
   async getRecentDonations() {
     const [rows] = await pool.execute(`
-      SELECT id, donor_name, donor_email, amount, donation_date, receipt_status
-      FROM donations
-      ORDER BY donation_date DESC
+      SELECT d.id, d.donor_name, d.donor_email, d.amount, d.donation_date,
+             d.receipt_status, dn.id AS donor_id
+      FROM donations d
+      LEFT JOIN donors dn ON d.donor_email = dn.email
+      ORDER BY d.donation_date DESC
       LIMIT 5
     `);
     return rows;
   },
-
 };
 
 export default dashboardRepository;

--- a/src/repositories/donationRepository.js
+++ b/src/repositories/donationRepository.js
@@ -1,49 +1,59 @@
 import { pool } from '../config/database.js';
 
 const donationRepository = {
+  async getDonations({
+    search,
+    status,
+    minAmount,
+    maxAmount,
+    page = 1,
+    limit = 25,
+  }) {
+    const MAX_LIMIT = 100;
+    const pageSize = Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
+    const safePage = Math.max(parseInt(page) || 1, 1);
+    const offset = (safePage - 1) * pageSize;
 
-  async getDonations({ search, status, minAmount, maxAmount, page = 1, limit = 25 }) {
-    const MAX_LIMIT = 100
-    const pageSize = Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT)
-    const safePage = Math.max(parseInt(page) || 1, 1)
-    const offset = (safePage - 1) * pageSize
-
-    let where = 'WHERE 1=1'
-    const params = []
+    let where = 'WHERE 1=1';
+    const params = [];
 
     if (search) {
-      where += ` AND (donor_name LIKE ? OR donor_email LIKE ?)`
-      params.push(`%${search}%`, `%${search}%`)
+      where += ` AND (d.donor_name LIKE ? OR d.donor_email LIKE ?)`;
+      params.push(`%${search}%`, `%${search}%`);
     }
 
     if (status) {
-      where += ` AND receipt_status = ?`
-      params.push(status)
+      where += ` AND d.receipt_status = ?`;
+      params.push(status);
     }
 
     if (minAmount) {
-      where += ` AND amount >= ?`
-      params.push(minAmount)
+      where += ` AND d.amount >= ?`;
+      params.push(minAmount);
     }
 
     if (maxAmount) {
-      where += ` AND amount <= ?`
-      params.push(maxAmount)
+      where += ` AND d.amount <= ?`;
+      params.push(maxAmount);
     }
 
     const [[countRows], [rows]] = await Promise.all([
       pool.execute(
-        `SELECT COUNT(*) AS total FROM donations ${where}`,
+        `SELECT COUNT(*) AS total FROM donations d ${where}`,
         params
       ),
       pool.execute(
-        `SELECT id, donor_name, donor_email, amount, donation_date, receipt_status
-         FROM donations ${where} ORDER BY donation_date DESC LIMIT ${pageSize} OFFSET ${offset}`,
+        `SELECT d.id, d.donor_name, d.donor_email, d.amount, d.donation_date,
+                d.receipt_status, dn.id AS donor_id
+         FROM donations d
+         LEFT JOIN donors dn ON d.donor_email = dn.email
+         ${where}
+         ORDER BY d.donation_date DESC LIMIT ${pageSize} OFFSET ${offset}`,
         params
       ),
-    ])
+    ]);
 
-    return { rows, total: parseInt(countRows[0].total) }
+    return { rows, total: parseInt(countRows[0].total) };
   },
 
   async getById(id) {
@@ -61,60 +71,66 @@ const donationRepository = {
         LEFT JOIN donors dn
         ON d.donor_email = dn.email
         WHERE d.id = ?
-    `
-    const [rows] = await pool.execute(sql, [id])
-    return rows[0] || null
+    `;
+    const [rows] = await pool.execute(sql, [id]);
+    return rows[0] || null;
   },
 
   async updateDonation(id, body) {
-    const { donor_name, donor_email, amount, donation_date, receipt_status } = body
-  
+    const { donor_name, donor_email, amount, donation_date, receipt_status } =
+      body;
+
     const sql = `
       UPDATE donations
       SET donor_name = ?, donor_email = ?, amount = ?, donation_date = ?, receipt_status = ?
       WHERE id = ?
-    `
-  
+    `;
+
     const [result] = await pool.execute(sql, [
       donor_name,
       donor_email,
       amount,
       donation_date,
       receipt_status,
-      id
-    ])
-  
-    return result
+      id,
+    ]);
+
+    return result;
   },
-  
+
   async deleteDonation(id) {
     const sql = `
       DELETE FROM donations
       WHERE id = ?
-    `
-  
-    const [result] = await pool.execute(sql, [id])
-  
-    return result
+    `;
+
+    const [result] = await pool.execute(sql, [id]);
+
+    return result;
   },
 
-  async createDonation({ donor_name, donor_email, amount, donation_date, receipt_status }) {
+  async createDonation({
+    donor_name,
+    donor_email,
+    amount,
+    donation_date,
+    receipt_status,
+  }) {
     const sql = `
       INSERT INTO donations (donor_name, donor_email, amount, donation_date, receipt_status)
       VALUES (?, ?, ?, ?, ?)
-    `
+    `;
 
     const [result] = await pool.execute(sql, [
       donor_name,
       donor_email,
       amount,
       donation_date,
-      receipt_status ?? 'pending'
-    ])
+      receipt_status ?? 'pending',
+    ]);
 
-    return result
-  }
-
+    return result;
+  },
 };
 
 export default donationRepository;


### PR DESCRIPTION
Closes https://github.com/zjovy/cwd-frontend/issues/14

## Summary
- `getDonations` and `getRecentDonations` now `LEFT JOIN donors ON donor_email = donors.email` and return `donor_id` on each row.
- Aliased filter columns (`d.donor_name`, `d.donor_email`, etc.) in the donations search WHERE clause so the join is unambiguous.

## Why
The frontend donations table needs a way to link a row to the matching donor profile page (`/donors/:id`). Including `donor_id` on the donation response avoids a second lookup per click.

## Related
Frontend PR: _linked below once opened_

## Test plan
- [ ] `GET /donations?limit=2` — each row includes `donor_id` (null if no matching donor)
- [ ] `GET /dashboard/recent-donations` — same
- [ ] Filters still work: `?search=alice`, `?status=pending`, `?minAmount=100&maxAmount=500`
- [ ] Pagination still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)