### PR TITLE
fix: deploy script permissions and Node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 *.ini
 node_modules/
 firebase-service-account.json
+
+# CDK
+infra/cdk.out/
+infra/node_modules/
+
+# SSH keys
+*.pem

--- a/infra/scripts/user-data.sh
+++ b/infra/scripts/user-data.sh
@@ -13,8 +13,8 @@ yum install -y nodejs
 # Install Nginx
 yum install -y nginx
 
-# Install git, jq (for parsing secrets)
-yum install -y git jq
+# Install git, jq, mariadb client (for parsing secrets and DB access)
+yum install -y git jq mariadb105
 
 # Install PM2 globally
 npm install -g pm2
@@ -26,61 +26,27 @@ yum install -y certbot python3-certbot-nginx
 systemctl enable nginx
 systemctl start nginx
 
-# Clone the repo (will be replaced by CI/CD later)
-cd /home/ec2-user
-git clone https://github.com/${GITHUB_ORG}/${GITHUB_REPO}.git cwd-backend || true
-cd cwd-backend
-npm ci --omit=dev
+# Clone the repo as ec2-user
+sudo -u ec2-user bash -c '
+  cd /home/ec2-user
+  git clone https://github.com/${GITHUB_ORG}/${GITHUB_REPO}.git cwd-backend || true
+  cd cwd-backend
+  npm ci --omit=dev
+'
 
-# Create scripts directory and fetch-secrets script
-mkdir -p scripts
-cat > scripts/fetch-secrets.sh << 'SCRIPT'
-#!/bin/bash
-set -e
-
-ENV_FILE="/home/ec2-user/cwd-backend/.env"
-REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
-
-# Static config
-cat > "$ENV_FILE" << 'EOF'
-NODE_ENV=production
-PORT=5050
-DATABASE_CLIENT=mysql
-FRONTEND_URL=${FRONTEND_URL}
-API_URL=https://${DOMAIN_NAME}
-EOF
-
-# DB credentials from Secrets Manager
-DB_SECRET=$(aws secretsmanager get-secret-value \
-  --secret-id cwd/db-credentials \
-  --region "$REGION" \
-  --query 'SecretString' --output text)
-
-echo "DB_HOST=$(echo $DB_SECRET | jq -r '.host')" >> "$ENV_FILE"
-echo "DB_PORT=$(echo $DB_SECRET | jq -r '.port')" >> "$ENV_FILE"
-echo "db_name=$(echo $DB_SECRET | jq -r '.dbname')" >> "$ENV_FILE"
-echo "dev_user=$(echo $DB_SECRET | jq -r '.username')" >> "$ENV_FILE"
-echo "dev_password=$(echo $DB_SECRET | jq -r '.password')" >> "$ENV_FILE"
-
-# Firebase key from Secrets Manager
-FIREBASE_KEY=$(aws secretsmanager get-secret-value \
-  --secret-id cwd/firebase-key \
-  --region "$REGION" \
-  --query 'SecretString' --output text)
-echo "FIREBASE_SERVICE_ACCOUNT_KEY='$FIREBASE_KEY'" >> "$ENV_FILE"
-
-chmod 600 "$ENV_FILE"
-chown ec2-user:ec2-user "$ENV_FILE"
-SCRIPT
-chmod +x scripts/fetch-secrets.sh
+# Make fetch-secrets.sh executable (it comes from the repo)
+chmod +x /home/ec2-user/cwd-backend/scripts/fetch-secrets.sh
 
 # Fetch secrets (will fail if secrets not yet populated — that's OK on first boot)
-./scripts/fetch-secrets.sh || echo "Secrets not yet available — run fetch-secrets.sh after populating Secrets Manager"
+sudo -u ec2-user bash -c '
+  cd /home/ec2-user/cwd-backend
+  ./scripts/fetch-secrets.sh
+' || echo "Secrets not yet available — run fetch-secrets.sh after populating Secrets Manager"
 
 # Set up PM2 as ec2-user
 sudo -u ec2-user bash -c '
   cd /home/ec2-user/cwd-backend
-  pm2 start src/server.js --name cwd-backend
+  pm2 start ecosystem.config.cjs
   pm2 startup systemd -u ec2-user --hp /home/ec2-user
   pm2 save
 '
@@ -89,7 +55,7 @@ sudo -u ec2-user bash -c '
 cat > /etc/nginx/conf.d/cwd-backend.conf << 'NGINX'
 server {
     listen 80;
-    server_name ${DOMAIN_NAME};
+    server_name _;
 
     location / {
         proxy_pass http://localhost:5050;


### PR DESCRIPTION
## Summary
- Fix root-owned `node_modules` causing EACCES on deploy (clone + npm ci now runs as ec2-user)
- Fix `fetch-secrets.sh` empty region (IMDSv2 token + us-east-1 fallback) — already on EC2, this ensures fresh deploys work
- Use `ecosystem.config.cjs` for PM2 instead of inline command
- Re-add CDK/.pem entries to .gitignore (lost in merge)

## Context
First deploy via GitHub Actions failed due to these issues. They were manually fixed on the EC2 and this PR ensures the infra code matches.

## Test plan
- [x] Manually verified on EC2 — app running with Node 22, health check passing
- [ ] Merge and verify next GitHub Actions deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)