### PR TITLE
fix: configure production domain URLs and add admin docs

### DIFF
--- a/docs/aws-deployment-guide.md
+++ b/docs/aws-deployment-guide.md
@@ -92,6 +92,46 @@ mysql -h $(echo $DB_SECRET | jq -r '.host') -u $(echo $DB_SECRET | jq -r '.usern
 pm2 restart cwd-backend
 ```
 
+### Make a user an admin
+
+New users who sign in get a default (non-admin) role. To grant admin access, we need to update their role in the database.
+
+**Option A: From the CLI (requires AWS CLI + SSH key)**
+
+```bash
+# SSH into EC2
+ssh -i cwd-backend-key.pem ec2-user@32.194.5.150
+
+# Connect to the database
+DB_SECRET=$(aws secretsmanager get-secret-value --secret-id cwd/db-credentials --region us-east-1 --query SecretString --output text)
+mysql -h $(echo $DB_SECRET | jq -r '.host') -u $(echo $DB_SECRET | jq -r '.username') -p$(echo $DB_SECRET | jq -r '.password') cwd_db
+
+# Then run:
+UPDATE users SET role = 'admin' WHERE email = 'their-email@example.com';
+```
+
+**Option B: From the AWS Console (no CLI needed)**
+
+1. Go to [AWS Console](https://console.aws.amazon.com) → **EC2** → **Instances** → select our instance (`i-0475ff86fd8ff4cce`)
+2. Click **Connect** → **Session Manager** → **Connect** (this opens a terminal in the browser, no SSH key needed)
+3. Run:
+   ```bash
+   sudo -u ec2-user bash
+   cd /home/ec2-user/cwd-backend
+   DB_SECRET=$(aws secretsmanager get-secret-value --secret-id cwd/db-credentials --region us-east-1 --query SecretString --output text)
+   mysql -h $(echo $DB_SECRET | jq -r '.host') -u $(echo $DB_SECRET | jq -r '.username') -p$(echo $DB_SECRET | jq -r '.password') cwd_db
+   ```
+4. Then run:
+   ```sql
+   UPDATE users SET role = 'admin' WHERE email = 'their-email@example.com';
+   ```
+
+**To verify it worked:**
+
+```sql
+SELECT email, role FROM users;
+```
+
 ### Update Firebase credentials
 
 ```

--- a/docs/aws-deployment-guide.md
+++ b/docs/aws-deployment-guide.md
@@ -11,7 +11,7 @@ Our backend runs on a single EC2 instance with a managed RDS database:
 - **Nginx** — reverse proxy, forwards traffic to Node.js on port 5050
 - **PM2** — process manager, keeps the app running and handles restarts
 
-The EC2 instance sits in a public subnet and is accessible via Elastic IP `32.194.5.150`. The RDS instance is in a private subnet (not publicly accessible). There is no domain configured yet — we access everything via the Elastic IP.
+The EC2 instance sits in a public subnet and is accessible via Elastic IP `32.194.5.150` (domain: `api.cwmarketfoundation.org`). The RDS instance is in a private subnet (not publicly accessible). The frontend is hosted on Firebase Hosting at `app.cwmarketfoundation.org`.
 
 **Key identifiers:**
 
@@ -194,16 +194,35 @@ Estimated ~$27/mo (or ~$4/mo if we are still in the AWS free tier).
 
 **Secrets fetch fails:** Check the EC2 IAM role has `secretsmanager:GetSecretValue` permissions. Verify you are targeting `us-east-1`.
 
-## 7. Adding a Domain Later
+## 7. Domain & SSL Setup
 
-1. Get a domain (or use an existing Squarespace domain)
-2. Add an A record: Host = `api`, Data = `32.194.5.150`
-3. Update Nginx config on EC2 — change `server_name _` to `server_name api.yourdomain.com`
-4. Run certbot for HTTPS:
+**Domain:** `cwmarketfoundation.org` (managed in Squarespace DNS)
+
+**DNS Records:**
+
+| Type | Host | Value |
+|------|------|-------|
+| A | api | 32.194.5.150 |
+| CNAME | app | cwd-donor-management.web.app |
+
+**Backend (api.cwmarketfoundation.org):**
+
+1. SSH into EC2
+2. Update Nginx config — change `server_name _` to `server_name api.cwmarketfoundation.org`:
    ```
-   sudo certbot --nginx -d api.yourdomain.com
+   sudo nano /etc/nginx/conf.d/cwd-backend.conf
    ```
-5. Update `FRONTEND_URL`/`API_URL` in `.env` and restart:
+3. Run Certbot for HTTPS:
    ```
-   pm2 restart cwd-backend
+   sudo certbot --nginx -d api.cwmarketfoundation.org
    ```
+4. Refresh secrets and restart:
+   ```
+   ./scripts/fetch-secrets.sh && pm2 restart cwd-backend
+   ```
+
+**Frontend (app.cwmarketfoundation.org):**
+
+Hosted on Firebase Hosting (project: `cwd-donor-management`). Custom domain is configured in Firebase Console → Hosting → Custom domains.
+
+Frontend deploys automatically via GitHub Actions on push to `main` in the frontend repo.

--- a/scripts/fetch-secrets.sh
+++ b/scripts/fetch-secrets.sh
@@ -19,8 +19,8 @@ DATABASE_CLIENT=mysql
 EOF
 
 # These should be set per-deployment (update before first deploy)
-echo "FRONTEND_URL=${FRONTEND_URL:-https://yourapp.com}" >> "$ENV_FILE"
-echo "API_URL=${API_URL:-https://api.yourapp.com}" >> "$ENV_FILE"
+echo "FRONTEND_URL=${FRONTEND_URL:-https://cwd-frontend.vercel.app}" >> "$ENV_FILE"
+echo "API_URL=${API_URL:-http://32.194.5.150}" >> "$ENV_FILE"
 
 # DB credentials from Secrets Manager
 DB_SECRET=$(aws secretsmanager get-secret-value \

--- a/scripts/fetch-secrets.sh
+++ b/scripts/fetch-secrets.sh
@@ -19,8 +19,8 @@ DATABASE_CLIENT=mysql
 EOF
 
 # These should be set per-deployment (update before first deploy)
-echo "FRONTEND_URL=${FRONTEND_URL:-https://cwd-frontend.vercel.app}" >> "$ENV_FILE"
-echo "API_URL=${API_URL:-http://32.194.5.150}" >> "$ENV_FILE"
+echo "FRONTEND_URL=${FRONTEND_URL:-https://app.cwmarketfoundation.org}" >> "$ENV_FILE"
+echo "API_URL=${API_URL:-https://api.cwmarketfoundation.org}" >> "$ENV_FILE"
 
 # DB credentials from Secrets Manager
 DB_SECRET=$(aws secretsmanager get-secret-value \


### PR DESCRIPTION
## Summary

- Update `fetch-secrets.sh` to use production domain URLs:
  - `FRONTEND_URL` → `https://app.cwmarketfoundation.org` (Firebase Hosting)
  - `API_URL` → `https://api.cwmarketfoundation.org` (EC2 + Certbot SSL)
- Add admin user setup instructions to deployment guide (CLI + AWS Console methods)
- Update deployment guide with domain/SSL setup, DNS records, and Firebase Hosting info

## Context

DNS is configured and SSL is live. Merging this will trigger a deploy that updates the backend `.env` with the correct URLs, enabling CORS for the frontend.

## Test plan

- [ ] Merge and verify deploy succeeds (GitHub Actions)
- [ ] Confirm frontend at `https://app.cwmarketfoundation.org` can communicate with backend
- [ ] Verify CORS headers allow the new frontend origin