### PR TITLE
Added endpoint for getting donations from a certain time period (startdate - enddate)

### DIFF
--- a/src/controllers/dashboardController.js
+++ b/src/controllers/dashboardController.js
@@ -47,8 +47,8 @@ const dashboardController = {
 
   async getRangeTrend(req, res) {
     const { startDate, endDate, bucket = 'month' } = req.query;
-    if (!['month', 'week', 'day'].includes(bucket))
-      return res.status(400).json({ error: 'bucket must be month, week, or day' });
+    if (!['month', 'week', 'day', 'year'].includes(bucket))
+      return res.status(400).json({ error: 'bucket must be month, week, day, or year' });
     const dateError = validateDateRange(startDate, endDate);
     if (dateError) return res.status(400).json({ error: dateError });
     try {

--- a/src/controllers/dashboardController.js
+++ b/src/controllers/dashboardController.js
@@ -1,4 +1,5 @@
 import dashboardRepository from '../repositories/dashboardRepository.js';
+import { validateDateRange } from '../utils/dateValidation.js';
 
 const dashboardController = {
   async getDashboardSummary(req, res) {
@@ -24,6 +25,34 @@ const dashboardController = {
   async getLast6MonthsDonations(_req, res) {
     try {
       const data = await dashboardRepository.getLast6MonthsDonations();
+      res.json(data);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async getRangeSummary(req, res) {
+    const { startDate, endDate } = req.query;
+    const dateError = validateDateRange(startDate, endDate);
+    if (dateError) return res.status(400).json({ error: dateError });
+    try {
+      const data = await dashboardRepository.getRangeSummary({ startDate, endDate });
+      res.json(data);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async getRangeTrend(req, res) {
+    const { startDate, endDate, bucket = 'month' } = req.query;
+    if (!['month', 'week', 'day'].includes(bucket))
+      return res.status(400).json({ error: 'bucket must be month, week, or day' });
+    const dateError = validateDateRange(startDate, endDate);
+    if (dateError) return res.status(400).json({ error: dateError });
+    try {
+      const data = await dashboardRepository.getRangeTrend({ startDate, endDate, bucket });
       res.json(data);
     } catch (err) {
       console.error(err);

--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -4,12 +4,14 @@ import donorRepository from '../repositories/donorRepository.js';
 const donationController = {
   async getDonations(req, res) {
     try {
-      const { search, status, minAmount, maxAmount, page, limit } = req.query;
+      const { search, status, minAmount, maxAmount, startDate, endDate, page, limit } = req.query;
       const { rows, total } = await donationRepository.getDonations({
         search,
         status,
         minAmount,
         maxAmount,
+        startDate,
+        endDate,
         page,
         limit,
       });

--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -1,10 +1,13 @@
 import donationRepository from '../repositories/donationRepository.js';
 import donorRepository from '../repositories/donorRepository.js';
+import { validateDateRange } from '../utils/dateValidation.js';
 
 const donationController = {
   async getDonations(req, res) {
     try {
       const { search, status, minAmount, maxAmount, startDate, endDate, page, limit } = req.query;
+      const dateError = validateDateRange(startDate, endDate);
+      if (dateError) return res.status(400).json({ error: dateError });
       const { rows, total } = await donationRepository.getDonations({
         search,
         status,

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -396,6 +396,9 @@ export default {
     } else if (bucket === 'day') {
       labelExpr = `DATE_FORMAT(donation_date, '%b %d, %Y')`;
       keyExpr = `DATE_FORMAT(donation_date, '%Y-%m-%d')`;
+    } else if (bucket === 'year') {
+      labelExpr = `DATE_FORMAT(donation_date, '%Y')`;
+      keyExpr = `DATE_FORMAT(donation_date, '%Y')`;
     } else {
       labelExpr = `DATE_FORMAT(donation_date, '%b %Y')`;
       keyExpr = `DATE_FORMAT(donation_date, '%Y-%m')`;

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -40,12 +40,17 @@ export default {
     status,
     minAmount,
     maxAmount,
+    startDate,
+    endDate,
     page = 1,
-    limit = 25,
+    limit,
   }) {
+    const hasDateFilter = startDate || endDate;
     const MAX_LIMIT = 100;
-    const pageSize = Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
-    const safePage = Math.max(parseInt(page) || 1, 1);
+    const pageSize = hasDateFilter && !limit
+      ? 10000
+      : Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
+    const safePage = hasDateFilter && !limit ? 1 : Math.max(parseInt(page) || 1, 1);
     const offset = (safePage - 1) * pageSize;
 
     let where = 'WHERE 1=1';
@@ -66,6 +71,14 @@ export default {
     if (maxAmount) {
       where += ` AND d.amount <= ?`;
       params.push(maxAmount);
+    }
+    if (startDate) {
+      where += ` AND d.donation_date >= ?`;
+      params.push(startDate);
+    }
+    if (endDate) {
+      where += ` AND d.donation_date <= ?`;
+      params.push(endDate);
     }
 
     const [[countRows], [rows]] = await Promise.all([

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -43,14 +43,11 @@ export default {
     startDate,
     endDate,
     page = 1,
-    limit,
+    limit = 25,
   }) {
-    const hasDateFilter = startDate || endDate;
     const MAX_LIMIT = 100;
-    const pageSize = hasDateFilter && !limit
-      ? 10000
-      : Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
-    const safePage = hasDateFilter && !limit ? 1 : Math.max(parseInt(page) || 1, 1);
+    const pageSize = Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
+    const safePage = Math.max(parseInt(page) || 1, 1);
     const offset = (safePage - 1) * pageSize;
 
     let where = 'WHERE 1=1';
@@ -355,6 +352,63 @@ export default {
       GROUP BY month_key, month
       ORDER BY month_key
     `);
+    return rows;
+  },
+
+  async getRangeSummary({ startDate, endDate } = {}) {
+    let where = 'WHERE 1=1';
+    const params = [];
+    if (startDate) {
+      where += ' AND donation_date >= ?';
+      params.push(startDate);
+    }
+    if (endDate) {
+      where += ' AND donation_date <= ?';
+      params.push(endDate);
+    }
+    const [rows] = await pool.execute(
+      `SELECT COALESCE(SUM(amount), 0) AS total_amount, COUNT(*) AS donation_count
+       FROM donations ${where}`,
+      params
+    );
+    return {
+      total_amount: parseFloat(rows[0].total_amount),
+      donation_count: parseInt(rows[0].donation_count),
+    };
+  },
+
+  async getRangeTrend({ startDate, endDate, bucket = 'month' } = {}) {
+    let where = 'WHERE 1=1';
+    const params = [];
+    if (startDate) {
+      where += ' AND donation_date >= ?';
+      params.push(startDate);
+    }
+    if (endDate) {
+      where += ' AND donation_date <= ?';
+      params.push(endDate);
+    }
+
+    let labelExpr, keyExpr;
+    if (bucket === 'week') {
+      labelExpr = `DATE_FORMAT(DATE_SUB(donation_date, INTERVAL WEEKDAY(donation_date) DAY), '%b %d, %Y')`;
+      keyExpr = `DATE_FORMAT(DATE_SUB(donation_date, INTERVAL WEEKDAY(donation_date) DAY), '%Y-%m-%d')`;
+    } else if (bucket === 'day') {
+      labelExpr = `DATE_FORMAT(donation_date, '%b %d, %Y')`;
+      keyExpr = `DATE_FORMAT(donation_date, '%Y-%m-%d')`;
+    } else {
+      labelExpr = `DATE_FORMAT(donation_date, '%b %Y')`;
+      keyExpr = `DATE_FORMAT(donation_date, '%Y-%m')`;
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT ${labelExpr} AS label, ${keyExpr} AS bucket_key,
+              COALESCE(SUM(amount), 0) AS amount
+       FROM donations ${where}
+       GROUP BY bucket_key, label
+       ORDER BY bucket_key`,
+      params
+    );
     return rows;
   },
 };

--- a/src/providers/postgresProvider.js
+++ b/src/providers/postgresProvider.js
@@ -431,6 +431,9 @@ export default {
     } else if (bucket === 'day') {
       labelExpr = `TO_CHAR(donation_date, 'Mon DD, YYYY')`;
       keyExpr = `TO_CHAR(donation_date, 'YYYY-MM-DD')`;
+    } else if (bucket === 'year') {
+      labelExpr = `TO_CHAR(donation_date, 'YYYY')`;
+      keyExpr = `TO_CHAR(donation_date, 'YYYY')`;
     } else {
       labelExpr = `TO_CHAR(donation_date, 'Mon YYYY')`;
       keyExpr = `TO_CHAR(donation_date, 'YYYY-MM')`;

--- a/src/providers/postgresProvider.js
+++ b/src/providers/postgresProvider.js
@@ -45,14 +45,11 @@ export default {
     startDate,
     endDate,
     page = 1,
-    limit,
+    limit = 25,
   }) {
-    const hasDateFilter = startDate || endDate;
     const MAX_LIMIT = 100;
-    const pageSize = hasDateFilter && !limit
-      ? 10000
-      : Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
-    const safePage = hasDateFilter && !limit ? 1 : Math.max(parseInt(page) || 1, 1);
+    const pageSize = Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
+    const safePage = Math.max(parseInt(page) || 1, 1);
     const offset = (safePage - 1) * pageSize;
 
     let where = 'WHERE 1=1';
@@ -388,6 +385,65 @@ export default {
       GROUP BY month_key, month
       ORDER BY month_key
     `);
+    return rows;
+  },
+
+  async getRangeSummary({ startDate, endDate } = {}) {
+    let where = 'WHERE 1=1';
+    const params = [];
+    let i = 1;
+    if (startDate) {
+      where += ` AND donation_date >= $${i++}`;
+      params.push(startDate);
+    }
+    if (endDate) {
+      where += ` AND donation_date <= $${i++}`;
+      params.push(endDate);
+    }
+    const { rows } = await pgPool.query(
+      `SELECT COALESCE(SUM(amount), 0) AS total_amount, COUNT(*) AS donation_count
+       FROM donations ${where}`,
+      params
+    );
+    return {
+      total_amount: parseFloat(rows[0].total_amount),
+      donation_count: parseInt(rows[0].donation_count),
+    };
+  },
+
+  async getRangeTrend({ startDate, endDate, bucket = 'month' } = {}) {
+    let where = 'WHERE 1=1';
+    const params = [];
+    let i = 1;
+    if (startDate) {
+      where += ` AND donation_date >= $${i++}`;
+      params.push(startDate);
+    }
+    if (endDate) {
+      where += ` AND donation_date <= $${i++}`;
+      params.push(endDate);
+    }
+
+    let labelExpr, keyExpr;
+    if (bucket === 'week') {
+      labelExpr = `TO_CHAR(DATE_TRUNC('week', donation_date), 'Mon DD, YYYY')`;
+      keyExpr = `TO_CHAR(DATE_TRUNC('week', donation_date), 'YYYY-MM-DD')`;
+    } else if (bucket === 'day') {
+      labelExpr = `TO_CHAR(donation_date, 'Mon DD, YYYY')`;
+      keyExpr = `TO_CHAR(donation_date, 'YYYY-MM-DD')`;
+    } else {
+      labelExpr = `TO_CHAR(donation_date, 'Mon YYYY')`;
+      keyExpr = `TO_CHAR(donation_date, 'YYYY-MM')`;
+    }
+
+    const { rows } = await pgPool.query(
+      `SELECT ${labelExpr} AS label, ${keyExpr} AS bucket_key,
+              COALESCE(SUM(amount), 0) AS amount
+       FROM donations ${where}
+       GROUP BY bucket_key, label
+       ORDER BY bucket_key`,
+      params
+    );
     return rows;
   },
 };

--- a/src/providers/postgresProvider.js
+++ b/src/providers/postgresProvider.js
@@ -42,12 +42,17 @@ export default {
     status,
     minAmount,
     maxAmount,
+    startDate,
+    endDate,
     page = 1,
-    limit = 25,
+    limit,
   }) {
+    const hasDateFilter = startDate || endDate;
     const MAX_LIMIT = 100;
-    const pageSize = Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
-    const safePage = Math.max(parseInt(page) || 1, 1);
+    const pageSize = hasDateFilter && !limit
+      ? 10000
+      : Math.min(Math.max(parseInt(limit) || 25, 1), MAX_LIMIT);
+    const safePage = hasDateFilter && !limit ? 1 : Math.max(parseInt(page) || 1, 1);
     const offset = (safePage - 1) * pageSize;
 
     let where = 'WHERE 1=1';
@@ -72,6 +77,16 @@ export default {
     if (maxAmount) {
       where += ` AND d.amount <= $${i}`;
       params.push(maxAmount);
+      i++;
+    }
+    if (startDate) {
+      where += ` AND d.donation_date >= $${i}`;
+      params.push(startDate);
+      i++;
+    }
+    if (endDate) {
+      where += ` AND d.donation_date <= $${i}`;
+      params.push(endDate);
       i++;
     }
 

--- a/src/repositories/dashboardRepository.js
+++ b/src/repositories/dashboardRepository.js
@@ -8,6 +8,8 @@ const dashboardRepository = {
   getDashboardSummary: () => provider.getDashboardSummary(),
   getDonationTrend: () => provider.getDonationTrend(),
   getLast6MonthsDonations: () => provider.getLast6MonthsDonations(),
+  getRangeSummary: (opts) => provider.getRangeSummary(opts),
+  getRangeTrend: (opts) => provider.getRangeTrend(opts),
 };
 
 export default dashboardRepository;

--- a/src/routes/dashboardRoutes.js
+++ b/src/routes/dashboardRoutes.js
@@ -14,4 +14,8 @@ router.get('/trend', dashboardController.getDonationTrend);
 
 router.get('/last6months', dashboardController.getLast6MonthsDonations);
 
+router.get('/range-summary', dashboardController.getRangeSummary);
+
+router.get('/range-trend', dashboardController.getRangeTrend);
+
 export default router;

--- a/src/utils/dateValidation.js
+++ b/src/utils/dateValidation.js
@@ -1,0 +1,18 @@
+const YYYY_MM_DD = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidDate(str) {
+  if (!YYYY_MM_DD.test(str)) return false;
+  const d = new Date(str + 'T00:00:00');
+  return !isNaN(d.getTime()) && d.toISOString().slice(0, 10) === str;
+}
+
+// Returns an error string or null
+export function validateDateRange(startDate, endDate) {
+  if (startDate !== undefined && !isValidDate(startDate))
+    return 'startDate must be a valid YYYY-MM-DD date';
+  if (endDate !== undefined && !isValidDate(endDate))
+    return 'endDate must be a valid YYYY-MM-DD date';
+  if (startDate && endDate && startDate > endDate)
+    return 'startDate must not be after endDate';
+  return null;
+}


### PR DESCRIPTION
Fixed custom date filtering for donations and charts so selecting ranges like “Past 6 Months” or custom dates actually updates the data correctly
Added backend support for filtering donations by start/end date
Fixed a bug where charts and donation lists were reading the wrong date field, which caused filtered results to appear empty
Removed backend result limits for chart filtering so charts can load the full dataset instead of getting cut off
Connected the dashboard charts and stats cards together so they stay synced when changing time ranges
Updated the dashboard UI so when a custom range is selected:
the 4 default stat cards collapse into 1 summary card
the summary card shows the selected date range
displays total money donated during that period
displays number of donations during that period
Added support for labels like “Past 6 Months” or custom date ranges such as “Jan 2 – May 2, 2026”
Fixed React state/update issues related to dashboard filtering behavior
(Same description as my frontend pr basically but without the first sentence)