### PR TITLE
fix: update placeholder URLs to cwmarketfoundation.org in CDK stack

### DIFF
--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -74,7 +74,7 @@ export class ComputeStack extends cdk.Stack {
     userData = userData.replace(/\$\{DOMAIN_NAME\}/g, domainName);
     userData = userData.replace(/\$\{GITHUB_ORG\}/g, githubOrg);
     userData = userData.replace(/\$\{GITHUB_REPO\}/g, githubRepo);
-    userData = userData.replace(/\$\{FRONTEND_URL\}/g, 'https://yourapp.com'); // Update this
+    userData = userData.replace(/\$\{FRONTEND_URL\}/g, 'https://app.cwmarketfoundation.org');
 
     // EC2 instance
     this.instance = new ec2.Instance(this, 'CwdBackend', {
@@ -107,7 +107,7 @@ export class ComputeStack extends cdk.Stack {
     // Outputs
     new cdk.CfnOutput(this, 'ElasticIpAddress', {
       value: this.elasticIp.attrPublicIp,
-      description: 'Add this as an A record in Squarespace DNS for api.yourapp.com',
+      description: 'Add this as an A record in Squarespace DNS for api.cwmarketfoundation.org',
     });
 
     new cdk.CfnOutput(this, 'InstanceId', {


### PR DESCRIPTION
## Summary

- Update `FRONTEND_URL` placeholder from `https://yourapp.com` to `https://app.cwmarketfoundation.org` in `compute-stack.ts`
- Update CDK output description to reference the correct domain

Small cleanup missed in the earlier deployment guide PR.