### PR TITLE
fix: enforce server-side admin check on delete donation

### DIFF
--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -69,6 +69,9 @@ const donationController = {
   },
 
   async deleteDonation(req, res) {
+    if (req.user?.role !== 'admin') {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
     const id = req.params.id;
     try {
       const result = await donationRepository.deleteDonation(id);


### PR DESCRIPTION
## Summary

- The delete donation endpoint previously relied on the frontend to hide the delete button from non-admin users, but the API itself had no role check — any authenticated user could call `DELETE /donations/:id` directly
- Added a server-side guard in `deleteDonation` that returns `403 Forbidden` if the caller's role is not `admin`
- `req.user.role` is already populated by `authMiddleware` from the database, so no new infrastructure is needed

## Test plan

- [ ] As an admin user, confirm `DELETE /donations/:id` still succeeds
- [ ] As a non-admin (pending/approved) user, confirm `DELETE /donations/:id` returns `403 Forbidden`
- [ ] Confirm all other donation endpoints (GET, POST, PUT) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)