### PR TITLE
fix: trust nginx proxy for express-rate-limit

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -4,14 +4,18 @@ import dotenv from 'dotenv';
 import express from 'express';
 
 import authRoutes from './routes/authRoutes.js';
+import dashboardRoutes from './routes/dashboardRoutes.js';
 import donationRoutes from './routes/donationRoutes.js';
 import donorRoutes from './routes/donorRoutes.js';
-import dashboardRoutes from './routes/dashboardRoutes.js';
 import syncRoutes from './routes/syncRoutes.js';
 
 dotenv.config();
 
 const app = express();
+
+// Trust the first proxy (nginx on the EC2 host terminates TLS and forwards to us).
+// Required for express-rate-limit to read X-Forwarded-For correctly.
+app.set('trust proxy', 1);
 
 const corsOptions = {
   origin: (origin, callback) => {


### PR DESCRIPTION
## Problem

Backend logs show:

\`\`\`
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default).
  code: 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR'
\`\`\`

nginx on EC2 terminates TLS and forwards requests with \`X-Forwarded-For\`, but Express doesn't trust it by default, so \`express-rate-limit\` can't read the real client IP.

## Fix

\`app.set('trust proxy', 1)\` — trust exactly one hop (nginx).

Not \`true\` (which would blindly trust the entire chain and let clients spoof IPs).