### PR TITLE
fix: store Stripe donation_date in foundation's local timezone

### DIFF
--- a/src/services/stripeSyncService.js
+++ b/src/services/stripeSyncService.js
@@ -1,13 +1,32 @@
 import Stripe from 'stripe';
+
 import donationRepository from '../repositories/donationRepository.js';
 import donorRepository from '../repositories/donorRepository.js';
 import syncMetaRepository from '../repositories/syncMetaRepository.js';
 
 const stripe = new Stripe(process.env.STRIPE_API_KEY);
 
+// Format a Unix timestamp (seconds) as YYYY-MM-DD in the foundation's local
+// timezone. Matches what Stripe shows in CSV exports / Dashboard, which use
+// the account's configured timezone (America/Chicago for Evanston, IL).
+const DONATION_TZ = 'America/Chicago';
+const dateFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: DONATION_TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+function formatLocalDate(unixSeconds) {
+  return dateFormatter.format(new Date(unixSeconds * 1000));
+}
+
 function extractDonorFields(pi) {
   const email =
-    pi.customer?.email ?? pi.receipt_email ?? pi.metadata?.email_address ?? null;
+    pi.customer?.email ??
+    pi.receipt_email ??
+    pi.metadata?.email_address ??
+    null;
 
   const rawName =
     pi.customer?.name ??
@@ -22,7 +41,14 @@ function extractDonorFields(pi) {
 
   const addr = pi.latest_charge?.billing_details?.address;
   const address = addr
-    ? [addr.line1, addr.line2, addr.city, addr.state, addr.postal_code, addr.country]
+    ? [
+        addr.line1,
+        addr.line2,
+        addr.city,
+        addr.state,
+        addr.postal_code,
+        addr.country,
+      ]
         .filter(Boolean)
         .join(', ') || null
     : null;
@@ -51,7 +77,9 @@ const stripeSyncService = {
     while (hasMore) {
       if (startingAfter) listParams.starting_after = startingAfter;
       const page = await stripe.paymentIntents.list(listParams);
-      paymentIntents.push(...page.data.filter((pi) => pi.status === 'succeeded'));
+      paymentIntents.push(
+        ...page.data.filter((pi) => pi.status === 'succeeded')
+      );
       hasMore = page.has_more;
       if (page.data.length > 0) {
         startingAfter = page.data[page.data.length - 1].id;
@@ -62,7 +90,8 @@ const stripeSyncService = {
 
     for (const pi of paymentIntents) {
       try {
-        const { email, first_name, last_name, phone, address } = extractDonorFields(pi);
+        const { email, first_name, last_name, phone, address } =
+          extractDonorFields(pi);
 
         let donor;
         if (email) {
@@ -74,7 +103,9 @@ const stripeSyncService = {
             address,
           });
         } else if (first_name || last_name) {
-          const alreadyExists = await donationRepository.existsByStripeId(pi.id);
+          const alreadyExists = await donationRepository.existsByStripeId(
+            pi.id
+          );
           if (alreadyExists) {
             skipped.push(pi.id);
             continue;
@@ -95,7 +126,7 @@ const stripeSyncService = {
         const result = await donationRepository.createStripeDonation({
           donor_id: donor.id,
           amount: pi.amount / 100,
-          donation_date: new Date(pi.created * 1000).toISOString().split('T')[0],
+          donation_date: formatLocalDate(pi.created),
           description: pi.metadata?.event_name ?? null,
           stripe_payment_intent_id: pi.id,
           stripe_created_at: pi.created,


### PR DESCRIPTION
## Problem

\`stripeSyncService.js\` stored \`donation_date\` via:

\`\`\`js
new Date(pi.created * 1000).toISOString().split('T')[0]
\`\`\`

\`.toISOString()\` always returns UTC. Stripe's CSV exports and dashboard display in the account's configured timezone (\`America/Chicago\` for Evanston, IL — US Central Time). Any donation made after ~6–7pm Central got bumped to the next day in the DB.

Example:
- Donation at 8pm Central on May 20
- Stripe shows: \`2026-05-20\`
- DB before fix: \`2026-05-21\`

## Fix

Use \`Intl.DateTimeFormat\` with \`timeZone: 'America/Chicago'\` to match Stripe's display.

## Separate issue: missing 39 name-only donations

The \`migrate_anonymous_donations_mysql.sql\` migration was never run on production (it makes \`donors.email\` nullable). Without it, the name-only path in the sync silently fails for all 39 charges that have a name but no email. **Not fixed in this PR — needs to be run manually on the EC2 server:**

\`\`\`bash
mysql -h <rds-host> -u cwd_admin -p<pw> cwd_db < sql/migrate_anonymous_donations_mysql.sql
\`\`\`

## Backfill required after merge

Existing rows have shifted dates. Truncate and re-sync to fix:

\`\`\`sql
SET FOREIGN_KEY_CHECKS=0;
TRUNCATE TABLE donations;
TRUNCATE TABLE donors;
TRUNCATE TABLE sync_meta;
SET FOREIGN_KEY_CHECKS=1;
\`\`\`

Then run the missing migration above, then click "Refresh Stripe" on the dashboard.

After all three steps:
- 562 donations (vs current 523)
- ~397 donors (vs current 359)

## Test plan

- [ ] Pick a donation made late evening Central in Stripe → DB row date matches Stripe (not shifted +1 day)
- [ ] Pick a daytime donation → still correct
- [ ] After running the schema migration + re-sync, donation count is 562