### PR TITLE
feat: bulk send donation receipts endpoint

### DIFF
--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -2,17 +2,26 @@ import donationRepository from '../repositories/donationRepository.js';
 import donorRepository from '../repositories/donorRepository.js';
 import emailService from '../services/emailService.js';
 import { buildReceiptPdf } from '../services/receiptPdfService.js';
+import { validateDateRange } from '../utils/dateValidation.js';
 import {
   RECEIPT_SUBJECT,
   buildReceiptMessage,
   messageToHtml,
 } from '../utils/receiptTemplate.js';
-import { validateDateRange } from '../utils/dateValidation.js';
 
 const donationController = {
   async getDonations(req, res) {
     try {
-      const { search, status, minAmount, maxAmount, startDate, endDate, page, limit } = req.query;
+      const {
+        search,
+        status,
+        minAmount,
+        maxAmount,
+        startDate,
+        endDate,
+        page,
+        limit,
+      } = req.query;
       const dateError = validateDateRange(startDate, endDate);
       if (dateError) return res.status(400).json({ error: dateError });
       const { rows, total } = await donationRepository.getDonations({
@@ -130,6 +139,65 @@ const donationController = {
       res
         .status(500)
         .json({ error: 'Failed to send receipt. Please try again.' });
+    }
+  },
+
+  async sendReceipts(req, res) {
+    try {
+      const { allUnsent, filters, body } = req.body || {};
+      let ids = Array.isArray(req.body?.ids) ? req.body.ids : null;
+
+      if (allUnsent) {
+        ids = await donationRepository.getUnsentIds(filters || {});
+      }
+
+      if (!Array.isArray(ids) || ids.length === 0) {
+        return res
+          .status(400)
+          .json({ error: 'No donations selected to send.' });
+      }
+
+      const sharedBody = typeof body === 'string' && body.trim() ? body : null;
+
+      const sent = [];
+      const failed = [];
+
+      for (const rawId of ids) {
+        const id = Number(rawId);
+        try {
+          const donation = await donationRepository.getById(id);
+          if (!donation) {
+            failed.push({ id, error: 'Not found' });
+            continue;
+          }
+          if (!donation.email) {
+            failed.push({ id, error: 'No email on file' });
+            continue;
+          }
+
+          const msg = sharedBody || buildReceiptMessage(donation);
+          const pdf = await buildReceiptPdf({ donation, message: msg });
+          await emailService.sendDonationReceipt({
+            html: messageToHtml(msg),
+            pdf,
+            subject: RECEIPT_SUBJECT,
+            text: msg,
+            to: donation.email,
+          });
+          await donationRepository.updateReceiptStatus(id, 'sent');
+          sent.push(id);
+        } catch (err) {
+          console.error(`[send-receipts] failed for id ${id}:`, err);
+          failed.push({ id, error: err.message || 'Send failed' });
+        }
+      }
+
+      res.json({ sent, failed, total: ids.length });
+    } catch (err) {
+      console.error('[send-receipts] error:', err);
+      res
+        .status(500)
+        .json({ error: 'Failed to send receipts. Please try again.' });
     }
   },
 

--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -6,8 +6,8 @@ import { validateDateRange } from '../utils/dateValidation.js';
 import {
   RECEIPT_SUBJECT,
   applyReceiptTemplate,
-  buildReceiptMessageTemplate,
   buildReceiptMessage,
+  buildReceiptMessageTemplate,
   messageToHtml,
 } from '../utils/receiptTemplate.js';
 
@@ -161,6 +161,11 @@ const donationController = {
           .json({ error: 'No donations selected to send.' });
       }
 
+      // Dedup explicit ids so callers can't trigger double sends with [1,1,2]
+      ids = [...new Set(ids.map((id) => Number(id)))].filter((n) =>
+        Number.isFinite(n)
+      );
+
       const sharedBody = typeof body === 'string' && body.trim() ? body : null;
 
       const sent = [];
@@ -172,9 +177,9 @@ const donationController = {
           .join(' ')
           .trim() || 'Unknown donor';
 
-      for (const rawId of ids) {
-        const id = Number(rawId);
+      for (const id of ids) {
         let donation = null;
+        let emailSent = false;
         try {
           donation = await donationRepository.getById(id);
           if (!donation) {
@@ -207,16 +212,35 @@ const donationController = {
             text: msg,
             to: donation.email,
           });
-          await donationRepository.updateReceiptStatus(id, 'sent');
+          emailSent = true;
+
+          // Email has gone out — if the DB update fails the donor row stays
+          // 'pending' and would be re-sent on the next bulk run. Surface this
+          // loudly and keep the id in `sent` so the UI doesn't prompt a retry.
+          try {
+            await donationRepository.updateReceiptStatus(id, 'sent');
+          } catch (dbErr) {
+            console.error(
+              `[send-receipts] CRITICAL: email sent for id ${id} (${donation.email}) but receipt_status update failed. Mark this donation as sent manually to avoid a duplicate receipt.`,
+              dbErr
+            );
+          }
           sent.push(id);
         } catch (err) {
           console.error(`[send-receipts] failed for id ${id}:`, err);
-          failed.push({
-            id,
-            name: donorLabel(donation),
-            email: donation?.email || null,
-            error: err.message || 'Send failed',
-          });
+          if (emailSent) {
+            // Shouldn't happen — only DB update is after `emailSent = true`,
+            // and that has its own catch. Guarding anyway so we never report
+            // a sent email as failed.
+            sent.push(id);
+          } else {
+            failed.push({
+              id,
+              name: donorLabel(donation),
+              email: donation?.email || null,
+              error: err.message || 'Send failed',
+            });
+          }
         }
       }
 
@@ -236,7 +260,10 @@ const donationController = {
 
       const recipients = rows.map((r) => ({
         id: r.id,
-        donorFullName: [r.first_name, r.last_name].filter(Boolean).join(' ').trim(),
+        donorFullName: [r.first_name, r.last_name]
+          .filter(Boolean)
+          .join(' ')
+          .trim(),
         donorEmail: r.email || '',
       }));
 

--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -162,16 +162,33 @@ const donationController = {
       const sent = [];
       const failed = [];
 
+      const donorLabel = (donation) =>
+        [donation?.first_name, donation?.last_name]
+          .filter(Boolean)
+          .join(' ')
+          .trim() || 'Unknown donor';
+
       for (const rawId of ids) {
         const id = Number(rawId);
+        let donation = null;
         try {
-          const donation = await donationRepository.getById(id);
+          donation = await donationRepository.getById(id);
           if (!donation) {
-            failed.push({ id, error: 'Not found' });
+            failed.push({
+              id,
+              name: 'Unknown donor',
+              email: null,
+              error: 'Not found',
+            });
             continue;
           }
           if (!donation.email) {
-            failed.push({ id, error: 'No email on file' });
+            failed.push({
+              id,
+              name: donorLabel(donation),
+              email: null,
+              error: 'No email on file',
+            });
             continue;
           }
 
@@ -188,7 +205,12 @@ const donationController = {
           sent.push(id);
         } catch (err) {
           console.error(`[send-receipts] failed for id ${id}:`, err);
-          failed.push({ id, error: err.message || 'Send failed' });
+          failed.push({
+            id,
+            name: donorLabel(donation),
+            email: donation?.email || null,
+            error: err.message || 'Send failed',
+          });
         }
       }
 
@@ -198,6 +220,25 @@ const donationController = {
       res
         .status(500)
         .json({ error: 'Failed to send receipts. Please try again.' });
+    }
+  },
+
+  async markReceiptsSent(req, res) {
+    try {
+      const ids = Array.isArray(req.body?.ids)
+        ? req.body.ids.map((id) => Number(id)).filter((n) => Number.isFinite(n))
+        : [];
+      if (ids.length === 0) {
+        return res.status(400).json({ error: 'No donation ids provided.' });
+      }
+      const { affectedRows } = await donationRepository.markManyReceiptStatus(
+        ids,
+        'sent'
+      );
+      res.json({ updated: affectedRows, ids });
+    } catch (err) {
+      console.error('[mark-receipts-sent] error:', err);
+      res.status(500).json({ error: 'Failed to mark donations as sent.' });
     }
   },
 

--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -5,6 +5,7 @@ import { buildReceiptPdf } from '../services/receiptPdfService.js';
 import { validateDateRange } from '../utils/dateValidation.js';
 import {
   RECEIPT_SUBJECT,
+  applyReceiptTemplate,
   buildReceiptMessage,
   messageToHtml,
 } from '../utils/receiptTemplate.js';
@@ -117,7 +118,9 @@ const donationController = {
           .json({ error: 'Donor has no email address on file.' });
       }
 
-      const body = String(req.body?.body || buildReceiptMessage(donation));
+      const body = req.body?.body
+        ? applyReceiptTemplate(String(req.body.body), donation)
+        : buildReceiptMessage(donation);
       const pdf = await buildReceiptPdf({ donation, message: body });
       const email = await emailService.sendDonationReceipt({
         html: messageToHtml(body),
@@ -192,7 +195,9 @@ const donationController = {
             continue;
           }
 
-          const msg = sharedBody || buildReceiptMessage(donation);
+          const msg = sharedBody
+            ? applyReceiptTemplate(sharedBody, donation)
+            : buildReceiptMessage(donation);
           const pdf = await buildReceiptPdf({ donation, message: msg });
           await emailService.sendDonationReceipt({
             html: messageToHtml(msg),

--- a/src/controllers/donationController.js
+++ b/src/controllers/donationController.js
@@ -6,6 +6,7 @@ import { validateDateRange } from '../utils/dateValidation.js';
 import {
   RECEIPT_SUBJECT,
   applyReceiptTemplate,
+  buildReceiptMessageTemplate,
   buildReceiptMessage,
   messageToHtml,
 } from '../utils/receiptTemplate.js';
@@ -225,6 +226,40 @@ const donationController = {
       res
         .status(500)
         .json({ error: 'Failed to send receipts. Please try again.' });
+    }
+  },
+
+  async getUnsentRecipients(req, res) {
+    try {
+      const { filters } = req.body || {};
+      const rows = await donationRepository.getUnsentRecipients(filters || {});
+
+      const recipients = rows.map((r) => ({
+        id: r.id,
+        donorFullName: [r.first_name, r.last_name].filter(Boolean).join(' ').trim(),
+        donorEmail: r.email || '',
+      }));
+
+      res.json({ recipients, total: recipients.length, cap: 20 });
+    } catch (err) {
+      console.error('[get-unsent-recipients] error:', err);
+      res
+        .status(500)
+        .json({ error: 'Failed to load unsent recipients. Please try again.' });
+    }
+  },
+
+  async getReceiptTemplate(req, res) {
+    try {
+      res.json({
+        subject: RECEIPT_SUBJECT,
+        body: buildReceiptMessageTemplate(),
+      });
+    } catch (err) {
+      console.error('[get-receipt-template] error:', err);
+      res
+        .status(500)
+        .json({ error: 'Failed to load receipt template. Please try again.' });
     }
   },
 

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -155,7 +155,10 @@ export default {
   },
 
   async getUnsentIds(filters = {}) {
-    const { where, params, limit } = this._buildUnsentWhere(filters);
+    const { where, params, limit } = this._buildUnsentWhere({
+      ...filters,
+      requireEmail: true,
+    });
     const [rows] = await pool.execute(
       `SELECT d.id FROM donations d JOIN donors dn ON d.donor_id = dn.id
        ${where} ORDER BY d.donation_date DESC, d.id DESC LIMIT ${limit}`,

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -109,6 +109,50 @@ export default {
     return rows[0] || null;
   },
 
+  async getUnsentIds({
+    search,
+    status,
+    minAmount,
+    maxAmount,
+    startDate,
+    endDate,
+  } = {}) {
+    let where = `WHERE COALESCE(d.receipt_status, 'pending') <> 'sent'`;
+    const params = [];
+
+    if (search) {
+      where += ` AND (dn.first_name LIKE ? OR dn.last_name LIKE ? OR dn.email LIKE ?)`;
+      params.push(`%${search}%`, `%${search}%`, `%${search}%`);
+    }
+    if (status && status !== 'sent') {
+      where += ` AND d.receipt_status = ?`;
+      params.push(status);
+    }
+    if (minAmount) {
+      where += ` AND d.amount >= ?`;
+      params.push(minAmount);
+    }
+    if (maxAmount) {
+      where += ` AND d.amount <= ?`;
+      params.push(maxAmount);
+    }
+    if (startDate) {
+      where += ` AND d.donation_date >= ?`;
+      params.push(startDate);
+    }
+    if (endDate) {
+      where += ` AND d.donation_date <= ?`;
+      params.push(endDate);
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT d.id FROM donations d JOIN donors dn ON d.donor_id = dn.id
+       ${where} ORDER BY d.donation_date DESC`,
+      params
+    );
+    return rows.map((r) => r.id);
+  },
+
   async createDonation({ donor_id, amount, donation_date, receipt_status }) {
     const [result] = await pool.execute(
       `INSERT INTO donations (donor_id, amount, donation_date, receipt_status)
@@ -196,7 +240,14 @@ export default {
       `INSERT IGNORE INTO donations
          (donor_id, amount, donation_date, description, stripe_payment_intent_id, stripe_created_at, receipt_status)
        VALUES (?, ?, ?, ?, ?, ?, 'pending')`,
-      [donor_id, amount, donation_date, description, stripe_payment_intent_id, stripe_created_at]
+      [
+        donor_id,
+        amount,
+        donation_date,
+        description,
+        stripe_payment_intent_id,
+        stripe_created_at,
+      ]
     );
     return { affectedRows: result.affectedRows };
   },

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -117,6 +117,7 @@ export default {
     startDate,
     endDate,
   } = {}) {
+    const LIMIT = 20;
     let where = `WHERE COALESCE(d.receipt_status, 'pending') <> 'sent'`;
     const params = [];
 
@@ -147,10 +148,62 @@ export default {
 
     const [rows] = await pool.execute(
       `SELECT d.id FROM donations d JOIN donors dn ON d.donor_id = dn.id
-       ${where} ORDER BY d.donation_date DESC`,
+       ${where} ORDER BY d.donation_date DESC, d.id DESC LIMIT ${LIMIT}`,
       params
     );
     return rows.map((r) => r.id);
+  },
+
+  async getUnsentRecipients({
+    search,
+    status,
+    minAmount,
+    maxAmount,
+    startDate,
+    endDate,
+  } = {}) {
+    const LIMIT = 20;
+    let where = `WHERE COALESCE(d.receipt_status, 'pending') <> 'sent'`;
+    const params = [];
+
+    if (search) {
+      where += ` AND (dn.first_name LIKE ? OR dn.last_name LIKE ? OR dn.email LIKE ?)`;
+      params.push(`%${search}%`, `%${search}%`, `%${search}%`);
+    }
+    if (status && status !== 'sent') {
+      where += ` AND d.receipt_status = ?`;
+      params.push(status);
+    }
+    if (minAmount) {
+      where += ` AND d.amount >= ?`;
+      params.push(minAmount);
+    }
+    if (maxAmount) {
+      where += ` AND d.amount <= ?`;
+      params.push(maxAmount);
+    }
+    if (startDate) {
+      where += ` AND d.donation_date >= ?`;
+      params.push(startDate);
+    }
+    if (endDate) {
+      where += ` AND d.donation_date <= ?`;
+      params.push(endDate);
+    }
+
+    // Recipients "being sent an email" must have an email address on file.
+    where += ` AND dn.email IS NOT NULL AND dn.email <> ''`;
+
+    const [rows] = await pool.execute(
+      `SELECT d.id, dn.first_name, dn.last_name, dn.email
+       FROM donations d
+       JOIN donors dn ON d.donor_id = dn.id
+       ${where}
+       ORDER BY d.donation_date DESC, d.id DESC
+       LIMIT ${LIMIT}`,
+      params
+    );
+    return rows;
   },
 
   async createDonation({ donor_id, amount, donation_date, receipt_status }) {

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -179,6 +179,18 @@ export default {
     return { affectedRows: result.affectedRows };
   },
 
+  async markManyReceiptStatus(ids, receipt_status) {
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return { affectedRows: 0 };
+    }
+    const placeholders = ids.map(() => '?').join(',');
+    const [result] = await pool.execute(
+      `UPDATE donations SET receipt_status = ? WHERE id IN (${placeholders})`,
+      [receipt_status, ...ids]
+    );
+    return { affectedRows: result.affectedRows };
+  },
+
   async deleteDonation(id) {
     const conn = await pool.getConnection();
     try {

--- a/src/providers/mysqlProvider.js
+++ b/src/providers/mysqlProvider.js
@@ -109,13 +109,14 @@ export default {
     return rows[0] || null;
   },
 
-  async getUnsentIds({
+  _buildUnsentWhere({
     search,
     status,
     minAmount,
     maxAmount,
     startDate,
     endDate,
+    requireEmail,
   } = {}) {
     const LIMIT = 20;
     let where = `WHERE COALESCE(d.receipt_status, 'pending') <> 'sent'`;
@@ -146,61 +147,35 @@ export default {
       params.push(endDate);
     }
 
+    if (requireEmail) {
+      where += ` AND dn.email IS NOT NULL AND dn.email <> ''`;
+    }
+
+    return { where, params, limit: LIMIT };
+  },
+
+  async getUnsentIds(filters = {}) {
+    const { where, params, limit } = this._buildUnsentWhere(filters);
     const [rows] = await pool.execute(
       `SELECT d.id FROM donations d JOIN donors dn ON d.donor_id = dn.id
-       ${where} ORDER BY d.donation_date DESC, d.id DESC LIMIT ${LIMIT}`,
+       ${where} ORDER BY d.donation_date DESC, d.id DESC LIMIT ${limit}`,
       params
     );
     return rows.map((r) => r.id);
   },
 
-  async getUnsentRecipients({
-    search,
-    status,
-    minAmount,
-    maxAmount,
-    startDate,
-    endDate,
-  } = {}) {
-    const LIMIT = 20;
-    let where = `WHERE COALESCE(d.receipt_status, 'pending') <> 'sent'`;
-    const params = [];
-
-    if (search) {
-      where += ` AND (dn.first_name LIKE ? OR dn.last_name LIKE ? OR dn.email LIKE ?)`;
-      params.push(`%${search}%`, `%${search}%`, `%${search}%`);
-    }
-    if (status && status !== 'sent') {
-      where += ` AND d.receipt_status = ?`;
-      params.push(status);
-    }
-    if (minAmount) {
-      where += ` AND d.amount >= ?`;
-      params.push(minAmount);
-    }
-    if (maxAmount) {
-      where += ` AND d.amount <= ?`;
-      params.push(maxAmount);
-    }
-    if (startDate) {
-      where += ` AND d.donation_date >= ?`;
-      params.push(startDate);
-    }
-    if (endDate) {
-      where += ` AND d.donation_date <= ?`;
-      params.push(endDate);
-    }
-
-    // Recipients "being sent an email" must have an email address on file.
-    where += ` AND dn.email IS NOT NULL AND dn.email <> ''`;
-
+  async getUnsentRecipients(filters = {}) {
+    const { where, params, limit } = this._buildUnsentWhere({
+      ...filters,
+      requireEmail: true,
+    });
     const [rows] = await pool.execute(
       `SELECT d.id, dn.first_name, dn.last_name, dn.email
        FROM donations d
        JOIN donors dn ON d.donor_id = dn.id
        ${where}
        ORDER BY d.donation_date DESC, d.id DESC
-       LIMIT ${LIMIT}`,
+       LIMIT ${limit}`,
       params
     );
     return rows;

--- a/src/repositories/donationRepository.js
+++ b/src/repositories/donationRepository.js
@@ -9,6 +9,8 @@ const donationRepository = {
   createDonation: (data) => provider.createDonation(data),
   updateDonation: (id, body) => provider.updateDonation(id, body),
   updateReceiptStatus: (id, status) => provider.updateReceiptStatus(id, status),
+  markManyReceiptStatus: (ids, status) =>
+    provider.markManyReceiptStatus(ids, status),
   deleteDonation: (id) => provider.deleteDonation(id),
   getMaxStripeCreatedAt: () => provider.getMaxStripeCreatedAt(),
   existsByStripeId: (id) => provider.existsByStripeId(id),

--- a/src/repositories/donationRepository.js
+++ b/src/repositories/donationRepository.js
@@ -5,6 +5,7 @@ const provider = mysqlProvider;
 const donationRepository = {
   getDonations: (opts) => provider.getDonations(opts),
   getById: (id) => provider.getById(id),
+  getUnsentIds: (filters) => provider.getUnsentIds(filters),
   createDonation: (data) => provider.createDonation(data),
   updateDonation: (id, body) => provider.updateDonation(id, body),
   updateReceiptStatus: (id, status) => provider.updateReceiptStatus(id, status),

--- a/src/repositories/donationRepository.js
+++ b/src/repositories/donationRepository.js
@@ -6,6 +6,7 @@ const donationRepository = {
   getDonations: (opts) => provider.getDonations(opts),
   getById: (id) => provider.getById(id),
   getUnsentIds: (filters) => provider.getUnsentIds(filters),
+  getUnsentRecipients: (filters) => provider.getUnsentRecipients(filters),
   createDonation: (data) => provider.createDonation(data),
   updateDonation: (id, body) => provider.updateDonation(id, body),
   updateReceiptStatus: (id, status) => provider.updateReceiptStatus(id, status),

--- a/src/routes/donationRoutes.js
+++ b/src/routes/donationRoutes.js
@@ -9,6 +9,8 @@ const router = express.Router();
 router.use(authMiddleware, requireApprovalMiddleware);
 
 router.get('/', donationController.getDonations);
+router.get('/receipt-template', donationController.getReceiptTemplate);
+router.post('/unsent-recipients', donationController.getUnsentRecipients);
 router.post('/send-receipts', donationController.sendReceipts);
 router.post('/mark-sent', donationController.markReceiptsSent);
 router.get('/:id', donationController.getDonationDetail);

--- a/src/routes/donationRoutes.js
+++ b/src/routes/donationRoutes.js
@@ -9,10 +9,11 @@ const router = express.Router();
 router.use(authMiddleware, requireApprovalMiddleware);
 
 router.get('/', donationController.getDonations);
+router.post('/send-receipts', donationController.sendReceipts);
 router.get('/:id', donationController.getDonationDetail);
 router.post('/:id/send-receipt', donationController.sendReceipt);
 router.put('/:id', donationController.updateDonation);
 router.post('/', donationController.createDonation);
-router.delete("/:id", donationController.deleteDonation);
+router.delete('/:id', donationController.deleteDonation);
 
 export default router;

--- a/src/routes/donationRoutes.js
+++ b/src/routes/donationRoutes.js
@@ -10,6 +10,7 @@ router.use(authMiddleware, requireApprovalMiddleware);
 
 router.get('/', donationController.getDonations);
 router.post('/send-receipts', donationController.sendReceipts);
+router.post('/mark-sent', donationController.markReceiptsSent);
 router.get('/:id', donationController.getDonationDetail);
 router.post('/:id/send-receipt', donationController.sendReceipt);
 router.put('/:id', donationController.updateDonation);

--- a/src/utils/receiptTemplate.js
+++ b/src/utils/receiptTemplate.js
@@ -1,5 +1,8 @@
 export const RECEIPT_SUBJECT = 'Donation Receipt - C&W Market Foundation';
 
+export const RECEIPT_FIRST_NAME_PLACEHOLDER = '{{first_name}}';
+export const RECEIPT_AMOUNT_PLACEHOLDER = '{{amount}}';
+
 export function formatDonationAmount(amount) {
   const value = Number.parseFloat(amount || 0);
   return value.toLocaleString('en-US', {
@@ -8,11 +11,11 @@ export function formatDonationAmount(amount) {
   });
 }
 
-export function buildReceiptMessage(donation) {
+export function buildReceiptMessageTemplate() {
   return [
-    `Dear ${donation.first_name},`,
+    `Dear ${RECEIPT_FIRST_NAME_PLACEHOLDER},`,
     '',
-    `The C&W Market Foundation has received your generous gift of $${formatDonationAmount(donation.amount)} to support our annual efforts.`,
+    `The C&W Market Foundation has received your generous gift of $${RECEIPT_AMOUNT_PLACEHOLDER} to support our annual efforts.`,
     '',
     'All of us at the C&W Market Foundation appreciate our donors. We are very grateful for your contribution!',
     '',
@@ -24,6 +27,18 @@ export function buildReceiptMessage(donation) {
     'Sydni Craig',
     'Board President',
   ].join('\n');
+}
+
+export function applyReceiptTemplate(template, donation) {
+  const name = donation?.first_name || 'Donor';
+  const amount = formatDonationAmount(donation?.amount);
+  return String(template)
+    .replaceAll(RECEIPT_FIRST_NAME_PLACEHOLDER, name)
+    .replaceAll(RECEIPT_AMOUNT_PLACEHOLDER, amount);
+}
+
+export function buildReceiptMessage(donation) {
+  return applyReceiptTemplate(buildReceiptMessageTemplate(), donation);
 }
 
 function escapeHtml(value) {


### PR DESCRIPTION
Closes https://github.com/zjovy/cwd-frontend/issues/52

## Summary
- Adds `POST /donations/send-receipts` accepting either an explicit `ids` array (for "send selected") or `allUnsent: true` + `filters` (for "send all unsent matching filters").
- New repo/provider method `getUnsentIds(filters)` reuses the same filter set as `getDonations` and excludes `receipt_status = 'sent'`.
- Each receipt is generated and sent per-donation; failures are collected per-id and returned in `{ sent, failed, total }` so the UI can report partial success.
- Optional shared `body` override; when omitted, each donor gets the standard personalized template.

## Test plan
- [ ] `POST /donations/send-receipts` with `{ ids: [1,2,3] }` sends receipts and flips `receipt_status` to `sent`
- [ ] `POST /donations/send-receipts` with `{ allUnsent: true, filters: { search: ... } }` only targets unsent rows matching filters
- [ ] Donations with no email on file return in `failed` rather than 500ing the request
- [ ] Sending with `{ body: "custom" }` uses that text for every recipient; omitting it falls back to the per-donor template

🤖 Generated with [Claude Code](https://claude.com/claude-code)