### PR TITLE
fix: tighten receipt email HTML line spacing

### DIFF
--- a/src/utils/receiptTemplate.js
+++ b/src/utils/receiptTemplate.js
@@ -51,9 +51,6 @@ function escapeHtml(value) {
 }
 
 export function messageToHtml(message) {
-  // Use <br> per newline (not <p>) so email clients don't stack default
-  // paragraph margins on top of intentional blank lines. Signature titles
-  // then sit directly under names, matching the letter layout.
   const body = escapeHtml(message).split('\n').join('<br>');
   return `<div style="margin:0;line-height:1.5;">${body}</div>`;
 }

--- a/src/utils/receiptTemplate.js
+++ b/src/utils/receiptTemplate.js
@@ -51,8 +51,9 @@ function escapeHtml(value) {
 }
 
 export function messageToHtml(message) {
-  return escapeHtml(message)
-    .split('\n')
-    .map((line) => (line ? `<p>${line}</p>` : '<br>'))
-    .join('');
+  // Use <br> per newline (not <p>) so email clients don't stack default
+  // paragraph margins on top of intentional blank lines. Signature titles
+  // then sit directly under names, matching the letter layout.
+  const body = escapeHtml(message).split('\n').join('<br>');
+  return `<div style="margin:0;line-height:1.5;">${body}</div>`;
 }

--- a/src/utils/receiptTemplate.test.js
+++ b/src/utils/receiptTemplate.test.js
@@ -18,8 +18,6 @@ describe('messageToHtml', () => {
     assert.match(html, /^<div style="[^"]*">/);
     assert.match(html, /<\/div>$/);
 
-    // One <br> per newline so blank lines stay single visual gaps,
-    // and signature titles sit directly under names.
     assert.equal(
       html,
       '<div style="margin:0;line-height:1.5;">' +

--- a/src/utils/receiptTemplate.test.js
+++ b/src/utils/receiptTemplate.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildReceiptMessage,
+  messageToHtml,
+} from './receiptTemplate.js';
+
+describe('messageToHtml', () => {
+  it('preserves plain-text line breaks without stacking paragraph margins', () => {
+    const message = buildReceiptMessage({
+      amount: 10,
+      first_name: 'Jefferson',
+    });
+    const html = messageToHtml(message);
+
+    assert.equal(html.includes('<p>'), false);
+    assert.match(html, /^<div style="[^"]*">/);
+    assert.match(html, /<\/div>$/);
+
+    // One <br> per newline so blank lines stay single visual gaps,
+    // and signature titles sit directly under names.
+    assert.equal(
+      html,
+      '<div style="margin:0;line-height:1.5;">' +
+        'Dear Jefferson,<br><br>' +
+        'The C&amp;W Market Foundation has received your generous gift of $10.00 to support our annual efforts.<br><br>' +
+        'All of us at the C&amp;W Market Foundation appreciate our donors. We are very grateful for your contribution!<br><br>' +
+        'With gratitude,<br><br>' +
+        'Clarence and Wendy Weaver<br>' +
+        'Co-Founders<br><br>' +
+        'Sydni Craig<br>' +
+        'Board President' +
+        '</div>'
+    );
+  });
+
+  it('escapes HTML special characters in message text', () => {
+    const html = messageToHtml('Hello <script> & "friends"');
+    assert.equal(
+      html,
+      '<div style="margin:0;line-height:1.5;">Hello &lt;script&gt; &amp; &quot;friends&quot;</div>'
+    );
+  });
+});


### PR DESCRIPTION
Render receipt bodies with <br>-separated lines instead of <p> tags so email clients don't stack default paragraph margins on blank lines and signature titles sit directly under names.